### PR TITLE
Disable the "require-await" rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -127,7 +127,7 @@ module.exports = {
     'no-warning-comments': 0,
     'no-with': 2,
     radix: 2,
-    'require-await': 1,
+    'require-await': 0,
     'vars-on-top': 0,
     yoda: 1,
 


### PR DESCRIPTION
In some cases this rule brings more annoyance than value.

Take this function for example:

```
async function iWantPromise() {
  if (condition) {
    return notAPromise;
  }

  return new Promise(resolve => { });
}
```

In some cases using the `Promise` constructor is necessary; if I want this function to always return a `Promise`, even if not explicitly, then I have two options:
1. Make the function `async`
2. Wrap all the values in `Promise.resolve` and wrap everything in `try...catch` so that I can `Promise.reject` on error.

Option 1. is definitely more convenient and I don't think it's a bad style.