### PR TITLE
react/prop-types: degrade to warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -192,5 +192,6 @@ module.exports = {
     'react/no-unescaped-entities': 0,
     'react/jsx-key': 0,
     'react/jsx-no-target-blank': 0,
+    'react/prop-types': 1,
   },
 };


### PR DESCRIPTION
I propose to degrade this one to warning because:

- it generally doesn't indicate a bug (code will run)
- but you still want to fix it before you commit
- but until you commit you don't want so much noise in the editor